### PR TITLE
emulate `@svgr/webpack` documentation

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -23,12 +23,12 @@ const svgrLoaders = ({ nextConfig, isServer }) => {
 
   return [
     {
-      test: svgUrlRegExp,
+      test: svgRegExp,
       use: [svgrLoader, urlLoader]
     },
     {
-      test: svgRegExp,
-      exclude: svgUrlRegExp,
+      test: svgUrlRegExp,
+      exclude: svgRegExp,
       use: svgrLoader
     }
   ]

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -25,11 +25,6 @@ const svgrLoaders = ({ nextConfig, isServer }) => {
     {
       test: svgRegExp,
       use: [svgrLoader, urlLoader]
-    },
-    {
-      test: svgUrlRegExp,
-      exclude: svgRegExp,
-      use: svgrLoader
     }
   ]
 }


### PR DESCRIPTION
I realize this is a breaking change, but as the library stands now, you can't leverage SVGs as file paths and it doesn't match up directly with SVGR docs.

This change matches up properly with SVGR's own documentation on leveraging the webpack plugin in conjunction with `file-loader` and `url-loader` -> https://react-svgr.com/docs/webpack/#using-with-url-loader-or-file-loader

This change would mean inline SVG imports would look like:

```jsx
import { ReactComponent as Whatever } from './some-svg.svg';

const SomeComponent = () => <Whatever />
```

and then you can use `svg` files as file paths like so:

```jsx
import src from './some-svg.svg';

const SomeComponent = () => <img src={src} alt="" />
```